### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-cloud-connector/src/main/java/org/springframework/credhub/cloud/CredHubInterpolationServiceDataPostProcessor.java
+++ b/spring-credhub-cloud-connector/src/main/java/org/springframework/credhub/cloud/CredHubInterpolationServiceDataPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-cloud-connector/src/main/java/org/springframework/credhub/cloud/package-info.java
+++ b/spring-credhub-cloud-connector/src/main/java/org/springframework/credhub/cloud/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-cloud-connector/src/test/java/org/springframework/credhub/cloud/CredHubInterpolationServiceDataPostProcessorTests.java
+++ b/spring-credhub-cloud-connector/src/test/java/org/springframework/credhub/cloud/CredHubInterpolationServiceDataPostProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/ClientHttpRequestFactoryFactory.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/ClientHttpRequestFactoryFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/CredHubTemplateFactory.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/CredHubTemplateFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/OAuth2CredHubTemplateFactory.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/OAuth2CredHubTemplateFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubClient.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubClient.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubException.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubProperties.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubProperties.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/RestOperationsCallback.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/RestOperationsCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ClientOptions.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ClientOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredHubRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredHubRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialDetails.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialDetailsData.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialDetailsData.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialName.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialName.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialPermissions.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialPermissions.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialRequest.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialSummary.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialSummary.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialSummaryData.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialSummaryData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialType.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialType.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/KeyLength.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/KeyLength.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/KeyPairCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/KeyPairCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/KeyParameters.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/KeyParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ParametersRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ParametersRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ServiceInstanceCredentialName.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ServiceInstanceCredentialName.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ServicesData.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ServicesData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/SimpleCredentialName.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/SimpleCredentialName.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/StringCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/StringCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateParameters.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateParametersRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateParametersRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/json/JsonCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/json/JsonCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/json/JsonCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/json/JsonCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/json/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/json/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordParameters.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordParametersRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordParametersRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/Actor.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/Actor.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/ActorType.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/ActorType.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/CredentialPermission.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/CredentialPermission.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/Operation.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/Operation.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaParameters.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaParametersRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaParametersRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshParameters.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshParametersRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshParametersRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/UserCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/UserCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/UserCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/UserCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/UserParametersRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/UserParametersRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/utils/JsonUtils.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/utils/JsonUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/value/ValueCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/value/ValueCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/value/ValueCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/value/ValueCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/value/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/value/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/configuration/ClientHttpRequestFactoryFactoryTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/configuration/ClientHttpRequestFactoryFactoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubClientUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubClientUnitTests.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailCertificateUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailCertificateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailJsonUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailJsonUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailPasswordUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailPasswordUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailRsaUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailRsaUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailSshUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailSshUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailUnitTestsBase.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailUnitTestsBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailUserUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailUserUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailValueUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateDetailValueUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateSummaryResponseUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateSummaryResponseUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateUnitTestsBase.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubTemplateUnitTestsBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/CredHubRequestUnitTestsBase.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/CredHubRequestUnitTestsBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/CredentialSummaryDataUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/CredentialSummaryDataUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/JsonParsingUnitTestsBase.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/JsonParsingUnitTestsBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/ServiceInstanceCredentialNameUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/ServiceInstanceCredentialNameUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/SimpleCredentialNameUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/SimpleCredentialNameUnitTests.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/certificate/CertificateCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/certificate/CertificateCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/certificate/CertificateCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/certificate/CertificateCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/certificate/CertificateParametersRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/certificate/CertificateParametersRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/json/JsonCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/json/JsonCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/json/JsonCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/json/JsonCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/password/PasswordCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/password/PasswordCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/password/PasswordCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/password/PasswordCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/password/PasswordParametersRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/password/PasswordParametersRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/permissions/CredentialPermissionsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/permissions/CredentialPermissionsUnitTests.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/rsa/RsaCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/rsa/RsaCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/rsa/RsaCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/rsa/RsaCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/rsa/RsaParametersRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/rsa/RsaParametersRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/ssh/SshCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/ssh/SshCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/ssh/SshCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/ssh/SshCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/ssh/SshParametersRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/ssh/SshParametersRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/user/UserCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/user/UserCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/user/UserCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/user/UserCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/user/UserParametersRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/user/UserParametersRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/value/ValueCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/value/ValueCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/value/ValueCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/value/ValueCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-demo/src/main/java/org/springframework/credhub/demo/Application.java
+++ b/spring-credhub-demo/src/main/java/org/springframework/credhub/demo/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-demo/src/main/java/org/springframework/credhub/demo/CredHubDemoController.java
+++ b/spring-credhub-demo/src/main/java/org/springframework/credhub/demo/CredHubDemoController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubAutoConfiguration.java
+++ b/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubTemplateAutoConfiguration.java
+++ b/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubTemplateAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/package-info.java
+++ b/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 114 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).