### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-cloud-connector/src/main/java/org/springframework/credhub/cloud/CredHubInterpolationServiceDataPostProcessor.java
+++ b/spring-credhub-cloud-connector/src/main/java/org/springframework/credhub/cloud/CredHubInterpolationServiceDataPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-cloud-connector/src/main/java/org/springframework/credhub/cloud/package-info.java
+++ b/spring-credhub-cloud-connector/src/main/java/org/springframework/credhub/cloud/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-cloud-connector/src/test/java/org/springframework/credhub/cloud/CredHubInterpolationServiceDataPostProcessorTests.java
+++ b/spring-credhub-cloud-connector/src/test/java/org/springframework/credhub/cloud/CredHubInterpolationServiceDataPostProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/ClientHttpConnectorFactory.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/ClientHttpConnectorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/ClientHttpRequestFactoryFactory.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/ClientHttpRequestFactoryFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/CredHubTemplateFactory.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/CredHubTemplateFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/SslCertificateUtils.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/SslCertificateUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubException.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubOAuth2RequestInterceptor.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubOAuth2RequestInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubProperties.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubProperties.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubRestTemplateFactory.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubRestTemplateFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubWebClientFactory.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubWebClientFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/ExceptionUtils.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/ExceptionUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/ReactiveCredHubOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/ReactiveCredHubOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/ReactiveCredHubTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/ReactiveCredHubTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/RestOperationsCallback.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/RestOperationsCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/certificate/CredHubCertificateOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/certificate/CredHubCertificateOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/certificate/CredHubCertificateTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/certificate/CredHubCertificateTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/certificate/ReactiveCredHubCertificateOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/certificate/ReactiveCredHubCertificateOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/certificate/ReactiveCredHubCertificateTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/certificate/ReactiveCredHubCertificateTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/certificate/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/certificate/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/credential/CredHubCredentialOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/credential/CredHubCredentialOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/credential/CredHubCredentialTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/credential/CredHubCredentialTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/credential/ReactiveCredHubCredentialOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/credential/ReactiveCredHubCredentialOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/credential/ReactiveCredHubCredentialTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/credential/ReactiveCredHubCredentialTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/credential/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/credential/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/info/CredHubInfoOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/info/CredHubInfoOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/info/CredHubInfoTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/info/CredHubInfoTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/info/ReactiveCredHubInfoOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/info/ReactiveCredHubInfoOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/info/ReactiveCredHubInfoTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/info/ReactiveCredHubInfoTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/info/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/info/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/interpolation/CredHubInterpolationOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/interpolation/CredHubInterpolationOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/interpolation/CredHubInterpolationTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/interpolation/CredHubInterpolationTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/interpolation/ReactiveCredHubInterpolationOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/interpolation/ReactiveCredHubInterpolationOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/interpolation/ReactiveCredHubInterpolationTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/interpolation/ReactiveCredHubInterpolationTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/interpolation/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/interpolation/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/permission/CredHubPermissionOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/permission/CredHubPermissionOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/permission/CredHubPermissionTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/permission/CredHubPermissionTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/permission/ReactiveCredHubPermissionOperations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/permission/ReactiveCredHubPermissionOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/permission/ReactiveCredHubPermissionTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/permission/ReactiveCredHubPermissionTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/permission/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/permission/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/permissionV2/CredHubPermissionV2Operations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/permissionV2/CredHubPermissionV2Operations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/permissionV2/CredHubPermissionV2Template.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/permissionV2/CredHubPermissionV2Template.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/permissionV2/ReactiveCredHubPermissionV2Operations.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/permissionV2/ReactiveCredHubPermissionV2Operations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/permissionV2/ReactiveCredHubPermissionV2Template.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/permissionV2/ReactiveCredHubPermissionV2Template.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/permissionV2/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/permissionV2/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ClientOptions.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ClientOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredHubRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredHubRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialDetails.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialDetailsData.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialDetailsData.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialName.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialName.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialPath.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialPath.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialPathData.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialPathData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialPermission.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialPermission.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialPermissions.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialPermissions.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialRequest.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialSummary.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialSummary.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialSummaryData.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialSummaryData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialType.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialType.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/KeyLength.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/KeyLength.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/KeyPairCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/KeyPairCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/KeyParameters.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/KeyParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ParametersRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ParametersRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ServiceInstanceCredentialName.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ServiceInstanceCredentialName.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ServicesData.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ServicesData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/SimpleCredentialName.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/SimpleCredentialName.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/StringCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/StringCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateCredentialDetails.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateCredentialDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateParameters.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateParametersRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateParametersRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateSummary.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateSummary.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateSummaryData.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/CertificateSummaryData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/certificate/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/info/VersionInfo.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/info/VersionInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/info/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/info/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/json/JsonCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/json/JsonCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/json/JsonCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/json/JsonCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/json/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/json/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordParameters.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordParametersRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/PasswordParametersRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/password/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/Actor.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/Actor.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/ActorType.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/ActorType.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/Operation.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/Operation.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/Permission.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/Permission.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/permissions/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaParameters.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaParametersRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/RsaParametersRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/rsa/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshParameters.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshParametersRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/SshParametersRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/ssh/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/UserCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/UserCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/UserCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/UserCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/UserParametersRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/UserParametersRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/user/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/utils/JsonUtils.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/utils/JsonUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/utils/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/utils/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/value/ValueCredential.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/value/ValueCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/value/ValueCredentialRequest.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/value/ValueCredentialRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/value/package-info.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/value/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/configuration/ClientHttpConnectorFactoryTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/configuration/ClientHttpConnectorFactoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/configuration/ClientHttpRequestFactoryFactoryTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/configuration/ClientHttpRequestFactoryFactoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubRestTemplateFactoryUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubRestTemplateFactoryUnitTests.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubWebClientFactoryTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/CredHubWebClientFactoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/certificate/CredHubCertificateTemplateUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/certificate/CredHubCertificateTemplateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubCredentialTemplateSummaryUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubCredentialTemplateSummaryUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubCredentialTemplateUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubCredentialTemplateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubCredentialTemplateUnitTestsBase.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubCredentialTemplateUnitTestsBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailCertificateUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailCertificateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailJsonUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailJsonUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailPasswordUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailPasswordUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailRsaUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailRsaUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailSshUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailSshUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailUnitTestsBase.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailUnitTestsBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailUserUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailUserUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailValueUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/credential/CredHubTemplateDetailValueUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/info/CredHubInfoTemplateUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/info/CredHubInfoTemplateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/interpolation/CredHubInterpolationTemplateUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/interpolation/CredHubInterpolationTemplateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/permission/CredHubPermissionTemplateUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/permission/CredHubPermissionTemplateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/core/permissionV2/CredHubPermissionV2TemplateUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/core/permissionV2/CredHubPermissionV2TemplateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/CertificateSummaryDataTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/CertificateSummaryDataTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/CredHubRequestUnitTestsBase.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/CredHubRequestUnitTestsBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/CredentialSummaryDataUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/CredentialSummaryDataUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/JsonParsingUnitTestsBase.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/JsonParsingUnitTestsBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/JsonPathAssert.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/JsonPathAssert.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/JsonTestUtils.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/JsonTestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/ServiceInstanceCredentialNameUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/ServiceInstanceCredentialNameUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/SimpleCredentialNameUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/SimpleCredentialNameUnitTests.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/certificate/CertificateCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/certificate/CertificateCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/certificate/CertificateCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/certificate/CertificateCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/certificate/CertificateParametersRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/certificate/CertificateParametersRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/info/VersionInfoTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/info/VersionInfoTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/json/JsonCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/json/JsonCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/json/JsonCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/json/JsonCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/password/PasswordCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/password/PasswordCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/password/PasswordCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/password/PasswordCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/password/PasswordParametersRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/password/PasswordParametersRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/permissions/CredentialPermissionUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/permissions/CredentialPermissionUnitTests.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/permissions/CredentialPermissionsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/permissions/CredentialPermissionsUnitTests.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/rsa/RsaCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/rsa/RsaCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/rsa/RsaCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/rsa/RsaCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/rsa/RsaParametersRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/rsa/RsaParametersRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/ssh/SshCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/ssh/SshCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/ssh/SshCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/ssh/SshCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/ssh/SshParametersRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/ssh/SshParametersRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/user/UserCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/user/UserCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/user/UserCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/user/UserCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/user/UserParametersRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/user/UserParametersRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/value/ValueCredentialDetailsUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/value/ValueCredentialDetailsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/support/value/ValueCredentialRequestUnitTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/support/value/ValueCredentialRequestUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-demo/src/main/java/org/springframework/credhub/demo/Application.java
+++ b/spring-credhub-demo/src/main/java/org/springframework/credhub/demo/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-demo/src/main/java/org/springframework/credhub/demo/CredHubDemoController.java
+++ b/spring-credhub-demo/src/main/java/org/springframework/credhub/demo/CredHubDemoController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/CertificateIntegrationTests.java
+++ b/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/CertificateIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/CredHubIntegrationTests.java
+++ b/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/CredHubIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/CredentialIntegrationTests.java
+++ b/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/CredentialIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/InfoIntegrationTests.java
+++ b/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/InfoIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/InterpolationIntegrationTests.java
+++ b/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/InterpolationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/PermissionIntegrationTests.java
+++ b/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/PermissionIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/PermissionV2IntegrationTests.java
+++ b/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/PermissionV2IntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/TestApplication.java
+++ b/spring-credhub-integration-tests/src/test/java/org/springframework/credhub/integration/TestApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactiveCertificateIntegrationTests.java
+++ b/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactiveCertificateIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactiveCredHubIntegrationTests.java
+++ b/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactiveCredHubIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactiveCredentialIntegrationTests.java
+++ b/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactiveCredentialIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactiveInfoIntegrationTests.java
+++ b/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactiveInfoIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactiveInterpolationIntegrationTests.java
+++ b/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactiveInterpolationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactivePermissionIntegrationTests.java
+++ b/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactivePermissionIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactivePermissionV2IntegrationTests.java
+++ b/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/ReactivePermissionV2IntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/TestApplication.java
+++ b/spring-credhub-reactive-integration-tests/src/test/java/org/springframework/credhub/integration/TestApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubAutoConfiguration.java
+++ b/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubOAuth2AutoConfiguration.java
+++ b/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubOAuth2AutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubTemplateAutoConfiguration.java
+++ b/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubTemplateAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/package-info.java
+++ b/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-starter/src/test/java/org/springframework/credhub/autoconfig/CredHubAutoConfigurationTests.java
+++ b/spring-credhub-starter/src/test/java/org/springframework/credhub/autoconfig/CredHubAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-starter/src/test/java/org/springframework/credhub/autoconfig/CredHubOAuth2AutoConfigurationTests.java
+++ b/spring-credhub-starter/src/test/java/org/springframework/credhub/autoconfig/CredHubOAuth2AutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-credhub-starter/src/test/java/org/springframework/credhub/autoconfig/CredHubTemplateAutoConfigurationTests.java
+++ b/spring-credhub-starter/src/test/java/org/springframework/credhub/autoconfig/CredHubTemplateAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 191 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).