### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 image::https://build.spring.io/plugins/servlet/wittified/build-status/SPRINGCREDHUB-CORE[Build Status,link=https://build.spring.io/browse/SPRINGCREDHUB-CORE]
 
-image::https://spring.io/badges/spring-credhub/snapshot.svg[link=http://projects.spring.io/spring-credhub#quick-start]
+image::https://spring.io/badges/spring-credhub/snapshot.svg[link=https://projects.spring.io/spring-credhub#quick-start]
 
 = Spring CredHub
 
@@ -27,8 +27,8 @@ $ ./gradlew install
 === Working with the code
 
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. 
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. 
 
 == Contributing
 
@@ -59,7 +59,7 @@ added after the original pull request but before a merge.
   you can import formatter settings using the
   `eclipse-code-formatter.xml` file from the
   link:/etc/ide/eclipse-code-formatter.xml[project]. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -71,6 +71,6 @@ added after the original pull request but before a merge.
 * Please include unit tests.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/spring-credhub-demo/README.adoc
+++ b/spring-credhub-demo/README.adoc
@@ -1,6 +1,6 @@
 = Spring CredHub Demo
 
-This application can be used to test CredHub connectivity by deploying it to a Cloud Foundry platform that has CredHub installed. The demo application includes a deployment manifest that makes it simple to deploy the application. Use the http://docs.cloudfoundry.org/cf-cli/getting-started.html[`cf` CLI] to target and authenticate to a Cloud Foundry platform, and run the following commands:
+This application can be used to test CredHub connectivity by deploying it to a Cloud Foundry platform that has CredHub installed. The demo application includes a deployment manifest that makes it simple to deploy the application. Use the https://docs.cloudfoundry.org/cf-cli/getting-started.html[`cf` CLI] to target and authenticate to a Cloud Foundry platform, and run the following commands:
 
 ----
 $ ../gradlew assemble
@@ -10,7 +10,7 @@ $ cf push -f manifest.yml
 After deploying the application, send an HTTP request to the demo application with this command:
 
 ----
-$ curl -X POST http://spring-credhub-demo.cf.example.com/test -d @demo.json -H "Content-type: application/json"
+$ curl -X POST https://spring-credhub-demo.cf.example.com/test -d @demo.json -H "Content-type: application/json"
 ----
 
 The application will write, retrieve, and delete a set of JSON credentials in CredHub and show the results of each request.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://spring-credhub-demo.cf.example.com/test (UnknownHostException) with 1 occurrences migrated to:  
  https://spring-credhub-demo.cf.example.com/test ([https](https://spring-credhub-demo.cf.example.com/test) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.cloudfoundry.org/cf-cli/getting-started.html with 1 occurrences migrated to:  
  https://docs.cloudfoundry.org/cf-cli/getting-started.html ([https](https://docs.cloudfoundry.org/cf-cli/getting-started.html) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://projects.spring.io/spring-credhub with 1 occurrences migrated to:  
  https://projects.spring.io/spring-credhub ([https](https://projects.spring.io/spring-credhub) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences
* http://username:password@rabbitmq-broker:12345/api with 1 occurrences