### PR TITLE
Allow to specify OAuth2AuthorizedClientManager for a CredHub template

### DIFF
--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubWebClientFactory.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubWebClientFactory.java
@@ -24,6 +24,7 @@ import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.codec.CodecConfigurer;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
+import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientProvider;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.endpoint.WebClientReactiveClientCredentialsTokenResponseClient;
@@ -72,8 +73,24 @@ class CredHubWebClientFactory {
 		ReactiveOAuth2AuthorizedClientProvider clientProvider =
 				buildClientProvider(clientHttpConnector);
 
-		DefaultReactiveOAuth2AuthorizedClientManager clientManager =
+		DefaultReactiveOAuth2AuthorizedClientManager defaultClientManager =
 				buildClientManager(clientRegistrationRepository, authorizedClientRepository, clientProvider);
+
+		return createWebClient(properties, clientHttpConnector, defaultClientManager);
+	}
+
+	/**
+	 * Create a {@link WebClient} configured for communication with a CredHub server.
+	 *
+	 * @param properties          CredHub connection properties
+	 * @param clientHttpConnector the {@link ClientHttpConnector} to use when
+	 *                            creating new connections
+	 * @param clientManager       OAuth2 client manager to use to authenticate a client
+	 * @return a configured {@link WebClient}
+	 */
+	static WebClient createWebClient(CredHubProperties properties,
+									 ClientHttpConnector clientHttpConnector,
+									 ReactiveOAuth2AuthorizedClientManager clientManager) {
 
 		ServerOAuth2AuthorizedClientExchangeFilterFunction oauth =
 				new ServerOAuth2AuthorizedClientExchangeFilterFunction(clientManager);

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/ReactiveCredHubTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/ReactiveCredHubTemplate.java
@@ -31,6 +31,7 @@ import org.springframework.credhub.core.permissionV2.ReactiveCredHubPermissionV2
 import org.springframework.credhub.core.permissionV2.ReactiveCredHubPermissionV2Template;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository;
 import org.springframework.util.Assert;
@@ -97,6 +98,25 @@ public class ReactiveCredHubTemplate implements ReactiveCredHubOperations {
 
 		this.webClient = CredHubWebClientFactory.createWebClient(credHubProperties, clientHttpConnector,
 				clientRegistrationRepository, authorizedClientRepository);
+		this.usingOAuth2 = true;
+	}
+
+    /**
+     * Create a new {@link ReactiveCredHubTemplate} using the provided base URI and
+     * {@link ClientHttpRequestFactory}.
+     *
+     * @param credHubProperties            connection properties for the CredHub server
+     * @param clientHttpConnector          the {@link ClientHttpConnector} to use when
+     *                                     creating new connections
+     * @param clientManager                an OAuth2 authorization client manager
+     */
+	public ReactiveCredHubTemplate(CredHubProperties credHubProperties, ClientHttpConnector clientHttpConnector,
+								   ReactiveOAuth2AuthorizedClientManager clientManager) {
+		Assert.notNull(credHubProperties, "credHubProperties must not be null");
+		Assert.notNull(clientHttpConnector, "clientHttpConnector must not be null");
+		Assert.notNull(clientManager, "clientManager must not be null");
+
+		this.webClient = CredHubWebClientFactory.createWebClient(credHubProperties, clientHttpConnector, clientManager);
 		this.usingOAuth2 = true;
 	}
 


### PR DESCRIPTION
Both default reactive and non-reactive OAuth2AuthorizedClientManagers
require a web request or a web exchange to exist, i.e. can only be used
within an active request. This makes using Spring Credhub in a CLI / background thread impossible.

This fix allows a developer to override CredHubTemplate using new
factory methods and provide a custom implementation of the manager capable
of operating outside of a request, e.g.
AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager.