### PR TITLE
Migrate to Boot 3.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@ A simple application that demonstrates the use of Spring CredHub is available in
 
 === Basic Compile and Test
 
-To build the source you will need to install JDK 1.8.
+To build the source you will need to install JDK 17.
 
 Spring CredHub uses Gradle for most build-related activities, and you should be able to get off the ground quite quickly by cloning the project you are interested in and typing
 

--- a/build.gradle
+++ b/build.gradle
@@ -119,8 +119,8 @@ configure(publishedProjects) {
 }
 
 subprojects {
-	sourceCompatibility = 1.8
-	targetCompatibility = 1.8
+	sourceCompatibility = 17
+	targetCompatibility = 17
 
 	tasks.withType(JavaCompile) {
 		options.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,13 @@ plugins {
 description = "Spring CredHub"
 
 ext {
-	springVersion = "5.3.23"
-	springBootVersion = "2.7.5"
-	springSecurityVersion = "5.7.5"
+	springVersion = "6.0.0-RC4"
+	springBootVersion = "3.0.0-RC2"
+	springSecurityVersion = "6.0.0-RC2"
 	reactorVersion = "2020.0.24"
 
 	okHttp3Version = "4.9.3"
-	httpClientVersion = "4.5.13"
+	httpClient5Version = "5.1.3"
 	nettyVersion = "4.1.84.Final"
 
 	junitVersion = "5.7.2"

--- a/ci/images/spring-credhub-ci/Dockerfile
+++ b/ci/images/spring-credhub-ci/Dockerfile
@@ -8,7 +8,7 @@ ENV JAVA_HOME /opt/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH
 RUN mkdir -p /opt/openjdk && \
     cd /opt/openjdk && \
-    curl -L https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u292b10.tar.gz | tar xz --strip-components=1
+    curl -L https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.5_8.tar.gz | tar xz --strip-components=1
 
 ADD https://raw.githubusercontent.com/spring-io/concourse-java-scripts/v0.0.4/concourse-java.sh /opt/
 ADD https://repo.spring.io/libs-snapshot/io/spring/concourse/releasescripts/concourse-release-scripts/0.3.4-SNAPSHOT/concourse-release-scripts-0.3.4-SNAPSHOT.jar /opt/

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/spring-credhub-core/build.gradle
+++ b/spring-credhub-core/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	}
 	securityImplementation("org.springframework.security:spring-security-config")
 
-	httpclientImplementation("org.apache.httpcomponents:httpclient:${httpClientVersion}") {
+	httpclientImplementation("org.apache.httpcomponents.client5:httpclient5:${httpClient5Version}") {
 		exclude(group: 'commons-logging', module: 'commons-logging')
 	}
 

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/ClientHttpRequestFactoryFactory.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/configuration/ClientHttpRequestFactoryFactory.java
@@ -16,33 +16,28 @@
 
 package org.springframework.credhub.configuration;
 
-import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
-import io.netty.handler.ssl.ClientAuth;
-import io.netty.handler.ssl.IdentityCipherSuiteFilter;
-import io.netty.handler.ssl.JdkSslContext;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.SslProvider;
 import okhttp3.OkHttpClient.Builder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.io.SocketConfig;
+import org.apache.hc.core5.util.Timeout;
 
 import org.springframework.credhub.support.ClientOptions;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.http.client.Netty4ClientHttpRequestFactory;
 import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.Assert;
@@ -68,9 +63,6 @@ public final class ClientHttpRequestFactoryFactory {
 	private static final boolean OKHTTP3_PRESENT = ClassUtils.isPresent("okhttp3.OkHttpClient",
 			ClientHttpRequestFactoryFactory.class.getClassLoader());
 
-	private static final boolean NETTY_PRESENT = ClassUtils.isPresent("io.netty.channel.nio.NioEventLoopGroup",
-			ClientHttpRequestFactoryFactory.class.getClassLoader());
-
 	private ClientHttpRequestFactoryFactory() {
 	}
 
@@ -94,13 +86,8 @@ public final class ClientHttpRequestFactoryFactory {
 				logger.info("Using OkHttp3 for HTTP connections");
 				return OkHttp3.usingOkHttp3(options);
 			}
-
-			if (NETTY_PRESENT) {
-				logger.info("Using Netty for HTTP connections");
-				return Netty.usingNetty(options);
-			}
 		}
-		catch (GeneralSecurityException | IOException ex) {
+		catch (GeneralSecurityException ex) {
 			logger.warn("Error configuring HTTP connections", ex);
 		}
 
@@ -121,7 +108,7 @@ public final class ClientHttpRequestFactoryFactory {
 			if (usingCustomCerts(options)) {
 				logger.warn("Trust material will not be configured when using "
 						+ "java.net.HttpUrlConnection. Use an alternate HTTP Client "
-						+ "(Apache HttpComponents HttpClient, OkHttp3, or Netty) when "
+						+ "(Apache HttpComponents HttpClient or OkHttp3) when "
 						+ "configuring CA certificates.");
 			}
 
@@ -149,27 +136,41 @@ public final class ClientHttpRequestFactoryFactory {
 
 		static ClientHttpRequestFactory usingHttpComponents(ClientOptions options) throws GeneralSecurityException {
 
+			SocketConfig.Builder socketConfigBuilder = SocketConfig.custom();
+			if (options.getReadTimeout() != null) {
+				socketConfigBuilder.setSoTimeout(Timeout.ofMilliseconds(options.getReadTimeoutMillis()));
+			}
+			SocketConfig socketConfig = socketConfigBuilder.build();
+
 			HttpClientBuilder httpClientBuilder = HttpClients.custom();
 
 			if (usingCustomCerts(options)) {
 				SSLContext sslContext = sslCertificateUtils.getSSLContext(options.getCaCertFiles());
 				SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext);
-
-				httpClientBuilder.setSSLSocketFactory(sslSocketFactory).setSSLContext(sslContext);
+				PoolingHttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder
+						.create()
+						.setSSLSocketFactory(sslSocketFactory)
+						.setDefaultSocketConfig(socketConfig)
+						.build();
+				httpClientBuilder.setConnectionManager(connectionManager);
 			}
 			else {
-				httpClientBuilder.setSSLContext(SSLContext.getDefault()).useSystemProperties();
+				SSLContext sslContext = SSLContext.getDefault();
+				SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext);
+				PoolingHttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder
+						.create()
+						.useSystemProperties()
+						.setSSLSocketFactory(sslSocketFactory)
+						.setDefaultSocketConfig(socketConfig)
+						.build();
+				httpClientBuilder.setConnectionManager(connectionManager);
 			}
 
 			RequestConfig.Builder requestConfigBuilder = RequestConfig.custom().setAuthenticationEnabled(true);
 
 			if (options.getConnectionTimeout() != null) {
-				requestConfigBuilder.setConnectTimeout(options.getConnectionTimeoutMillis());
+				requestConfigBuilder.setConnectTimeout(Timeout.ofMilliseconds(options.getConnectionTimeout().toMillis()));
 			}
-			if (options.getReadTimeout() != null) {
-				requestConfigBuilder.setSocketTimeout(options.getReadTimeoutMillis());
-			}
-
 			httpClientBuilder.setDefaultRequestConfig(requestConfigBuilder.build());
 
 			return new HttpComponentsClientHttpRequestFactory(httpClientBuilder.build());
@@ -211,47 +212,6 @@ public final class ClientHttpRequestFactoryFactory {
 			}
 
 			return new OkHttp3ClientHttpRequestFactory(builder.build());
-		}
-
-	}
-
-	/**
-	 * {@link ClientHttpRequestFactory} using Netty.
-	 *
-	 * @author Mark Paluch
-	 * @author Scott Frederick
-	 */
-	static class Netty {
-
-		@SuppressWarnings("deprecation")
-		static ClientHttpRequestFactory usingNetty(ClientOptions options) throws IOException, GeneralSecurityException {
-
-			final Netty4ClientHttpRequestFactory requestFactory = new Netty4ClientHttpRequestFactory();
-
-			if (options.getConnectionTimeout() != null) {
-				requestFactory.setConnectTimeout(options.getConnectionTimeoutMillis());
-			}
-			if (options.getReadTimeout() != null) {
-				requestFactory.setReadTimeout(options.getReadTimeoutMillis());
-			}
-
-			if (usingCustomCerts(options)) {
-				TrustManagerFactory trustManagerFactory = sslCertificateUtils
-						.createTrustManagerFactory(options.getCaCertFiles());
-
-				SslContext sslContext = SslContextBuilder.forClient().sslProvider(SslProvider.JDK)
-						.trustManager(trustManagerFactory).build();
-
-				requestFactory.setSslContext(sslContext);
-			}
-			else {
-				SslContext sslContext = new JdkSslContext(SSLContext.getDefault(), true, null,
-						IdentityCipherSuiteFilter.INSTANCE, null, ClientAuth.REQUIRE, null, false);
-
-				requestFactory.setSslContext(sslContext);
-			}
-
-			return requestFactory;
 		}
 
 	}

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubException.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/CredHubException.java
@@ -16,7 +16,7 @@
 
 package org.springframework.credhub.core;
 
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.web.client.HttpStatusCodeException;
 
 /**
@@ -37,10 +37,10 @@ public class CredHubException extends HttpStatusCodeException {
 
 	/**
 	 * Create a new exception with the provided error status code.
-	 * @param statusCode an {@link HttpStatus} indicating an error while attempting to
+	 * @param statusCode an {@link HttpStatusCode} indicating an error while attempting to
 	 * communicate with CredHub
 	 */
-	public CredHubException(HttpStatus statusCode) {
+	public CredHubException(HttpStatusCode statusCode) {
 		super(statusCode);
 	}
 

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/certificate/ReactiveCredHubCertificateTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/certificate/ReactiveCredHubCertificateTemplate.java
@@ -30,7 +30,7 @@ import org.springframework.credhub.support.CredentialName;
 import org.springframework.credhub.support.certificate.CertificateCredentialDetails;
 import org.springframework.credhub.support.certificate.CertificateSummary;
 import org.springframework.credhub.support.certificate.CertificateSummaryData;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.util.Assert;
 
 /**
@@ -73,7 +73,7 @@ public class ReactiveCredHubCertificateTemplate implements ReactiveCredHubCertif
 	@Override
 	public Flux<CertificateSummary> getAll() {
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.get().uri(BASE_URL_PATH).retrieve()
-				.onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(CertificateSummaryData.class)
+				.onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(CertificateSummaryData.class)
 				.flatMapMany((data) -> Flux.fromIterable(data.getCertificates())));
 	}
 
@@ -82,7 +82,7 @@ public class ReactiveCredHubCertificateTemplate implements ReactiveCredHubCertif
 		Assert.notNull(name, "certificate name must not be null");
 
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.get().uri(NAME_URL_QUERY, name.getName())
-				.retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError)
+				.retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError)
 				.bodyToMono(CertificateSummaryData.class)
 				.flatMapMany((data) -> Flux.fromIterable(data.getCertificates()))).single();
 	}
@@ -99,7 +99,7 @@ public class ReactiveCredHubCertificateTemplate implements ReactiveCredHubCertif
 
 		return this.credHubOperations
 				.doWithWebClient((webClient) -> webClient.post().uri(REGENERATE_URL_PATH, id).bodyValue(request)
-						.retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(ref));
+						.retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(ref));
 	}
 
 	@Override
@@ -113,7 +113,7 @@ public class ReactiveCredHubCertificateTemplate implements ReactiveCredHubCertif
 		request.put(SIGNED_BY_REQUEST_FIELD, certificateName.getName());
 
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.post().uri(BULK_REGENERATE_URL_PATH)
-				.bodyValue(request).retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToFlux(ref)
+				.bodyValue(request).retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToFlux(ref)
 				.flatMap((body) -> Flux.fromIterable(body.get(REGENERATED_CREDENTIALS_RESPONSE_FIELD))));
 	}
 
@@ -125,7 +125,7 @@ public class ReactiveCredHubCertificateTemplate implements ReactiveCredHubCertif
 
 		return this.credHubOperations
 				.doWithWebClient((webClient) -> webClient.put().uri(UPDATE_TRANSITIONAL_URL_PATH, id).bodyValue(request)
-						.retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError)
+						.retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError)
 						.bodyToFlux(CertificateCredentialDetails.class));
 	}
 

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/credential/ReactiveCredHubCredentialTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/credential/ReactiveCredHubCredentialTemplate.java
@@ -32,7 +32,7 @@ import org.springframework.credhub.support.CredentialRequest;
 import org.springframework.credhub.support.CredentialSummary;
 import org.springframework.credhub.support.CredentialSummaryData;
 import org.springframework.credhub.support.ParametersRequest;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.util.Assert;
 
 /**
@@ -80,7 +80,7 @@ public class ReactiveCredHubCredentialTemplate implements ReactiveCredHubCredent
 
 		return this.credHubOperations
 				.doWithWebClient((webClient) -> webClient.put().uri(BASE_URL_PATH).bodyValue(credentialRequest)
-						.retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(ref));
+						.retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(ref));
 	}
 
 	@Override
@@ -93,7 +93,7 @@ public class ReactiveCredHubCredentialTemplate implements ReactiveCredHubCredent
 
 		return this.credHubOperations
 				.doWithWebClient((webClient) -> webClient.post().uri(BASE_URL_PATH).bodyValue(parametersRequest)
-						.retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(ref));
+						.retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(ref));
 	}
 
 	@Override
@@ -109,7 +109,7 @@ public class ReactiveCredHubCredentialTemplate implements ReactiveCredHubCredent
 
 		return this.credHubOperations
 				.doWithWebClient((webClient) -> webClient.post().uri(REGENERATE_URL_PATH).bodyValue(request).retrieve()
-						.onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(ref));
+						.onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(ref));
 	}
 
 	@Override
@@ -121,7 +121,7 @@ public class ReactiveCredHubCredentialTemplate implements ReactiveCredHubCredent
 		};
 
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.get().uri(ID_URL_PATH, id).retrieve()
-				.onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(ref));
+				.onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(ref));
 	}
 
 	@Override
@@ -134,7 +134,7 @@ public class ReactiveCredHubCredentialTemplate implements ReactiveCredHubCredent
 
 		return this.credHubOperations
 				.doWithWebClient((webClient) -> webClient.get().uri(NAME_URL_QUERY_CURRENT, name.getName()).retrieve()
-						.onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(ref)
+						.onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(ref)
 						.map((body) -> body.getData().get(0)));
 	}
 
@@ -148,7 +148,7 @@ public class ReactiveCredHubCredentialTemplate implements ReactiveCredHubCredent
 		};
 
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.get().uri(NAME_URL_QUERY, name.getName())
-				.retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToFlux(ref)
+				.retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToFlux(ref)
 				.flatMap((body) -> Flux.fromIterable(body.getData())));
 	}
 
@@ -163,7 +163,7 @@ public class ReactiveCredHubCredentialTemplate implements ReactiveCredHubCredent
 
 		return this.credHubOperations
 				.doWithWebClient((webClient) -> webClient.get().uri(NAME_URL_QUERY_VERSIONS, name.getName(), versions)
-						.retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToFlux(ref)
+						.retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToFlux(ref)
 						.flatMap((body) -> Flux.fromIterable(body.getData())));
 	}
 
@@ -173,7 +173,7 @@ public class ReactiveCredHubCredentialTemplate implements ReactiveCredHubCredent
 
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.get()
 				.uri(NAME_LIKE_URL_QUERY, name.getName()).retrieve()
-				.onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(CredentialSummaryData.class)
+				.onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(CredentialSummaryData.class)
 				.flatMapMany((data) -> Flux.fromIterable(data.getCredentials())));
 	}
 
@@ -182,7 +182,7 @@ public class ReactiveCredHubCredentialTemplate implements ReactiveCredHubCredent
 		Assert.notNull(path, "credential path must not be null");
 
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.get().uri(PATH_URL_QUERY, path)
-				.retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError)
+				.retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError)
 				.bodyToMono(CredentialSummaryData.class)
 				.flatMapMany((data) -> Flux.fromIterable(data.getCredentials())));
 	}
@@ -193,7 +193,7 @@ public class ReactiveCredHubCredentialTemplate implements ReactiveCredHubCredent
 
 		return this.credHubOperations
 				.doWithWebClient((webClient) -> webClient.delete().uri(NAME_URL_QUERY, name.getName()).retrieve()
-						.onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(Void.class));
+						.onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(Void.class));
 	}
 
 }

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/info/ReactiveCredHubInfoTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/info/ReactiveCredHubInfoTemplate.java
@@ -21,7 +21,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.credhub.core.ExceptionUtils;
 import org.springframework.credhub.core.ReactiveCredHubOperations;
 import org.springframework.credhub.support.info.VersionInfo;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 
 /**
  * Implements the interaction with CredHub retrieve server information.
@@ -50,7 +50,7 @@ public class ReactiveCredHubInfoTemplate implements ReactiveCredHubInfoOperation
 	@Override
 	public Mono<VersionInfo> version() {
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.get().uri(VERSION_URL_PATH).retrieve()
-				.onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(VersionInfo.class));
+				.onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(VersionInfo.class));
 	}
 
 }

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/interpolation/ReactiveCredHubInterpolationTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/interpolation/ReactiveCredHubInterpolationTemplate.java
@@ -22,7 +22,7 @@ import org.springframework.credhub.core.CredHubOperations;
 import org.springframework.credhub.core.ExceptionUtils;
 import org.springframework.credhub.core.ReactiveCredHubOperations;
 import org.springframework.credhub.support.ServicesData;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.util.Assert;
 
 /**
@@ -52,7 +52,7 @@ public class ReactiveCredHubInterpolationTemplate implements ReactiveCredHubInte
 
 		return this.credHubOperations.doWithWebClient(
 				(webClient) -> webClient.post().uri(INTERPOLATE_URL_PATH).bodyValue(serviceData).retrieve()
-						.onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(ServicesData.class));
+						.onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(ServicesData.class));
 	}
 
 }

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/permission/ReactiveCredHubPermissionTemplate.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/permission/ReactiveCredHubPermissionTemplate.java
@@ -25,7 +25,7 @@ import org.springframework.credhub.support.CredentialName;
 import org.springframework.credhub.support.CredentialPermissions;
 import org.springframework.credhub.support.permissions.Actor;
 import org.springframework.credhub.support.permissions.Permission;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.util.Assert;
 
 /**
@@ -58,7 +58,7 @@ public class ReactiveCredHubPermissionTemplate implements ReactiveCredHubPermiss
 
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.get()
 				.uri(PERMISSIONS_URL_QUERY, name.getName()).retrieve()
-				.onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(CredentialPermissions.class)
+				.onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(CredentialPermissions.class)
 				.flatMapMany((data) -> Flux.fromIterable(data.getPermissions())));
 	}
 
@@ -70,7 +70,7 @@ public class ReactiveCredHubPermissionTemplate implements ReactiveCredHubPermiss
 
 		return this.credHubOperations.doWithWebClient(
 				(webClient) -> webClient.post().uri(PERMISSIONS_URL_PATH).bodyValue(credentialPermissions).retrieve()
-						.onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(Void.class));
+						.onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(Void.class));
 	}
 
 	@Override
@@ -80,7 +80,7 @@ public class ReactiveCredHubPermissionTemplate implements ReactiveCredHubPermiss
 
 		return this.credHubOperations.doWithWebClient(
 				(webClient) -> webClient.delete().uri(PERMISSIONS_ACTOR_URL_QUERY, name.getName(), actor.getIdentity())
-						.retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(Void.class));
+						.retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(Void.class));
 	}
 
 }

--- a/spring-credhub-core/src/main/java/org/springframework/credhub/core/permissionV2/ReactiveCredHubPermissionV2Template.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/core/permissionV2/ReactiveCredHubPermissionV2Template.java
@@ -24,7 +24,7 @@ import org.springframework.credhub.support.CredentialName;
 import org.springframework.credhub.support.CredentialPermission;
 import org.springframework.credhub.support.permissions.Actor;
 import org.springframework.credhub.support.permissions.Permission;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.util.Assert;
 
 /**
@@ -68,7 +68,7 @@ public class ReactiveCredHubPermissionV2Template implements ReactiveCredHubPermi
 		final CredentialPermission credentialPermission = new CredentialPermission(path, permission);
 
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.post().uri(PERMISSIONS_URL_PATH)
-				.bodyValue(credentialPermission).retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError)
+				.bodyValue(credentialPermission).retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError)
 				.bodyToMono(CredentialPermission.class));
 	}
 
@@ -79,7 +79,7 @@ public class ReactiveCredHubPermissionV2Template implements ReactiveCredHubPermi
 
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.get()
 				.uri(PERMISSIONS_PATH_ACTOR_URL_QUERY, path.getName(), actor.getIdentity()).retrieve()
-				.onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(CredentialPermission.class));
+				.onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(CredentialPermission.class));
 	}
 
 	@Override
@@ -92,7 +92,7 @@ public class ReactiveCredHubPermissionV2Template implements ReactiveCredHubPermi
 		final CredentialPermission credentialPermission = new CredentialPermission(path, permission);
 
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.put().uri(PERMISSIONS_ID_URL_PATH, id)
-				.bodyValue(credentialPermission).retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError)
+				.bodyValue(credentialPermission).retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError)
 				.bodyToMono(CredentialPermission.class));
 	}
 
@@ -101,7 +101,7 @@ public class ReactiveCredHubPermissionV2Template implements ReactiveCredHubPermi
 		Assert.notNull(id, "credential ID must not be null");
 
 		return this.credHubOperations.doWithWebClient((webClient) -> webClient.delete().uri(PERMISSIONS_ID_URL_PATH, id)
-				.retrieve().onStatus(HttpStatus::isError, ExceptionUtils::buildError).bodyToMono(Void.class));
+				.retrieve().onStatus(HttpStatusCode::isError, ExceptionUtils::buildError).bodyToMono(Void.class));
 	}
 
 }

--- a/spring-credhub-core/src/test/java/org/springframework/credhub/configuration/ClientHttpRequestFactoryFactoryTests.java
+++ b/spring-credhub-core/src/test/java/org/springframework/credhub/configuration/ClientHttpRequestFactoryFactoryTests.java
@@ -16,19 +16,17 @@
 
 package org.springframework.credhub.configuration;
 
-import org.apache.http.client.HttpClient;
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.credhub.configuration.ClientHttpRequestFactoryFactory.HttpComponents;
 import org.springframework.credhub.configuration.ClientHttpRequestFactoryFactory.HttpURLConnection;
-import org.springframework.credhub.configuration.ClientHttpRequestFactoryFactory.Netty;
 import org.springframework.credhub.configuration.ClientHttpRequestFactoryFactory.OkHttp3;
 import org.springframework.credhub.support.ClientOptions;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.http.client.Netty4ClientHttpRequestFactory;
 import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 
@@ -61,16 +59,6 @@ public class ClientHttpRequestFactoryFactoryTests {
 		ClientHttpRequestFactory factory = OkHttp3.usingOkHttp3(new ClientOptions());
 
 		assertThat(factory).isInstanceOf(OkHttp3ClientHttpRequestFactory.class);
-
-		((DisposableBean) factory).destroy();
-	}
-
-	@Test
-	@SuppressWarnings("deprecation")
-	public void nettyClientCreated() throws Exception {
-		ClientHttpRequestFactory factory = Netty.usingNetty(new ClientOptions());
-
-		assertThat(factory).isInstanceOf(Netty4ClientHttpRequestFactory.class);
 
 		((DisposableBean) factory).destroy();
 	}

--- a/spring-credhub-demo/build.gradle
+++ b/spring-credhub-demo/build.gradle
@@ -18,7 +18,7 @@ description = 'Spring CredHub Demo'
 
 buildscript {
 	ext {
-		springBootVersion = "2.7.0"
+		springBootVersion = "3.0.0-RC2"
 	}
 
 	dependencies {

--- a/spring-credhub-docs/build.gradle
+++ b/spring-credhub-docs/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-	id 'org.asciidoctor.jvm.convert' version '3.2.0'
+	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 dependencyManagement {

--- a/spring-credhub-integration-tests/build.gradle
+++ b/spring-credhub-integration-tests/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 	} else if (project.hasProperty("useNetty")) {
 		testImplementation("io.netty:netty-all")
 	} else {
-		testImplementation("org.apache.httpcomponents:httpclient")
+		testImplementation("org.apache.httpcomponents.client5:httpclient5:${httpClient5Version}")
 	}
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/spring-credhub-starter/build.gradle
+++ b/spring-credhub-starter/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	securityImplementation("org.springframework.security:spring-security-config")
 	securityImplementation("org.springframework.security:spring-security-oauth2-client")
 
-	httpclientImplementation("org.apache.httpcomponents:httpclient") {
+	httpclientImplementation("org.apache.httpcomponents.client5:httpclient5:${httpClient5Version}") {
 		exclude(group: 'commons-logging', module: 'commons-logging')
 	}
 

--- a/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubOAuth2AutoConfiguration.java
+++ b/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubOAuth2AutoConfiguration.java
@@ -71,7 +71,7 @@ public class CredHubOAuth2AutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnClass(name = "javax.servlet.http.HttpServletRequest")
+	@ConditionalOnClass(name = "jakarta.servlet.http.HttpServletRequest")
 	public ClientRegistrationRepository credHubClientRegistrationRepository() {
 		List<ClientRegistration> registrations = new ArrayList<>(
 				OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(this.properties).values());
@@ -86,7 +86,7 @@ public class CredHubOAuth2AutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnClass(name = "javax.servlet.http.HttpServletRequest")
+	@ConditionalOnClass(name = "jakarta.servlet.http.HttpServletRequest")
 	public OAuth2AuthorizedClientRepository credHubAuthorizedClientRepository(
 			ClientRegistrationRepository clientRegistrationRepository) {
 		return new AuthenticatedPrincipalOAuth2AuthorizedClientRepository(

--- a/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubTemplateConfiguration.java
+++ b/spring-credhub-starter/src/main/java/org/springframework/credhub/autoconfig/CredHubTemplateConfiguration.java
@@ -46,7 +46,7 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepo
 public class CredHubTemplateConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(name = "javax.servlet.http.HttpServletRequest")
+	@ConditionalOnClass(name = "jakarta.servlet.http.HttpServletRequest")
 	@ConditionalOnProperty(prefix = "spring.credhub.oauth2", name = "registration-id", havingValue = "false",
 			matchIfMissing = true)
 	static class CredHubTemplateBaseConfiguration {
@@ -68,7 +68,7 @@ public class CredHubTemplateConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(name = "javax.servlet.http.HttpServletRequest")
+	@ConditionalOnClass(name = "jakarta.servlet.http.HttpServletRequest")
 	@ConditionalOnProperty(prefix = "spring.credhub.oauth2", name = "registration-id")
 	@ConditionalOnMissingBean(OAuth2AuthorizedClientManager.class)
 	static class CredHubTemplateOAuth2Configuration {
@@ -95,7 +95,7 @@ public class CredHubTemplateConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(name = "javax.servlet.http.HttpServletRequest")
+	@ConditionalOnClass(name = "jakarta.servlet.http.HttpServletRequest")
 	@ConditionalOnProperty(prefix = "spring.credhub.oauth2", name = "registration-id")
 	@ConditionalOnBean(OAuth2AuthorizedClientManager.class)
 	static class CredHubTemplateOAuth2ClientConfiguration {

--- a/spring-credhub-starter/src/test/java/org/springframework/credhub/autoconfig/CredHubOAuth2AutoConfigurationTests.java
+++ b/spring-credhub-starter/src/test/java/org/springframework/credhub/autoconfig/CredHubOAuth2AutoConfigurationTests.java
@@ -81,7 +81,7 @@ public class CredHubOAuth2AutoConfigurationTests {
 
 	@Test
 	public void oauth2ContextConfiguredWithReactiveWebAppNoServlet() {
-		new ReactiveWebApplicationContextRunner().withClassLoader(new FilteredClassLoader("javax.servlet"))
+		new ReactiveWebApplicationContextRunner().withClassLoader(new FilteredClassLoader("jakarta.servlet"))
 				.withConfiguration(AutoConfigurations.of(this.configurations))
 				.withPropertyValues(this.oAuth2ClientProperties).run((context) -> {
 					assertServletOAuth2ContextNotConfigured(context);

--- a/spring-credhub-starter/src/test/java/org/springframework/credhub/autoconfig/CredHubTemplateAutoConfigurationTests.java
+++ b/spring-credhub-starter/src/test/java/org/springframework/credhub/autoconfig/CredHubTemplateAutoConfigurationTests.java
@@ -58,7 +58,7 @@ public class CredHubTemplateAutoConfigurationTests {
 			"org.springframework.security.oauth2.client");
 
 	private static final FilteredClassLoader SERVLET_AND_SECURITY_FILTERED_CLASS_LOADER = new FilteredClassLoader(
-			"javax.servlet.http.HttpServletRequest", "org.springframework.security.oauth2.client");
+			"jakarta.servlet.http.HttpServletRequest", "org.springframework.security.oauth2.client");
 
 	private static final FilteredClassLoader WEB_CLIENT_AND_SECURITY_FILTERED_CLASS_LOADER = new FilteredClassLoader(
 			"org.springframework.web.reactive.function.client", "org.springframework.security.oauth2.client");
@@ -67,7 +67,7 @@ public class CredHubTemplateAutoConfigurationTests {
 			.withConfiguration(
 					AutoConfigurations.of(ReactiveOAuth2ClientAutoConfiguration.class, CredHubAutoConfiguration.class,
 							CredHubOAuth2AutoConfiguration.class, CredHubTemplateAutoConfiguration.class))
-			.withInitializer(new ConditionEvaluationReportLoggingListener(LogLevel.INFO));
+			.withInitializer(ConditionEvaluationReportLoggingListener.forLogLevel(LogLevel.INFO));
 
 	@Test
 	public void credHubTemplatesConfigured() {


### PR DESCRIPTION
- fixes gh-99
- update jdk to 17
- update gradle to 7.5.1
- update to apache httpclient 5
- update asciidoctor gradle plugin for new gradle version
- removed Netty ClientHttpRequestFactory as the [Netty implementation has been removed](https://github.com/spring-projects/spring-framework/tree/main/spring-web/src/main/java/org/springframework/http/client) from the `org.springframework.http.client` package
- replace `javax.servlet` with `jakarta.servlet`
- replace `HttpStatus` with `HttpStatusCode`

I know a lot of the version updates are still RCs, so please let me know if I should create the PR instead against a separate branch. 

Also, I'm not entirely sure about removing the Netty ClientHttpRequestFactory, but as there was no implementation in spring 6 and it was already deprecated, I removed it. Happy to revise it upon feedback.