### PR TITLE
Fixed the docs build

### DIFF
--- a/spring-credhub-docs/build.gradle
+++ b/spring-credhub-docs/build.gradle
@@ -48,6 +48,7 @@ task prepareAsciidocBuild(type: Sync) {
 }
 
 asciidoctor {
+	dependsOn prepareAsciidocBuild
 	baseDirFollowsSourceFile()
 	configurations "asciidoctorExtensions"
 	outputOptions {


### PR DESCRIPTION
by adding a dependsOn clause to the Asciidoctor task so that the Asciidoctor setup task gets run.

(Nothing happens if the setup step isn't run.)