### PR TITLE
Remove duplicated "the"

### DIFF
--- a/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialDetails.java
+++ b/spring-credhub-core/src/main/java/org/springframework/credhub/support/CredentialDetails.java
@@ -68,7 +68,7 @@ public class CredentialDetails<T> extends CredentialSummary {
 	}
 
 	/**
-	 * Get the the CredHub-generated unique ID of the credential.
+	 * Get the CredHub-generated unique ID of the credential.
 	 * @return the credential ID
 	 */
 	public @Nullable String getId() {


### PR DESCRIPTION
This PR fixes a typo of "the the" to "the".